### PR TITLE
Updated mobx version to 5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-form",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Factorial form library",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "flat": "2.0.1"
   },
   "peerDependencies": {
-    "mobx": "^3.2.0"
+    "mobx": "^5.9.4"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -58,7 +58,7 @@
     "husky": "^0.13.4",
     "jest": "^20.0.4",
     "lint-staged": "^3.6.0",
-    "mobx": "^3.2.0",
+    "mobx": "^5.9.4",
     "prettier-standard": "^5.0.0",
     "rimraf": "^2.6.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2765,9 +2765,9 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
-mobx@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/mobx/-/mobx-3.2.0.tgz#5efb3280bc7f6eb9299a252c9ff9b4403cbd8c5a"
+mobx@^5.9.4:
+  version "5.9.4"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.9.4.tgz#1dee92aba33f67b7baeeb679e3bd376a12e55812"
 
 moment@2.21.0:
   version "2.21.0"


### PR DESCRIPTION
# WAT
Factorial is moving to mobx 5+. Factorial form needs to update its external dependencies accordingly.