### PR TITLE
Fix error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-form",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Factorial form library",
   "repository": {
     "type": "git",

--- a/src/Form.js
+++ b/src/Form.js
@@ -178,13 +178,15 @@ export default class Form {
 
     try {
       values = toJS(await fn())
-    } catch (errors) {
+    } catch (error) {
+      const { payload } = error
+
       runInAction('handleErrors-error', () => {
-        this.setErrors(toJS(errors))
+        this.setErrors(toJS(payload || error))
         this.cleanAll()
       })
 
-      throw errors
+      throw error
     }
 
     runInAction('handleErrors-done', () => {


### PR DESCRIPTION
# WAT
mobx-rest@3.0 returns [a new ErrorObject](https://github.com/masylum/mobx-rest/blob/master/src/ErrorObject.ts) and the error body response is stored in a `payload` object. Adapting factorial-form to this new reality.