### PR TITLE
A CLEAN-FORM FIX FOR FACTORIAL FORM

### DIFF
--- a/src/Field.ts
+++ b/src/Field.ts
@@ -109,7 +109,7 @@ export default class Field {
   }
 
   clean(): void {
-    this.originalValue = this.value
+    this.value = this.originalValue
   }
 
   setErrors(errors: Array<string> | null): void {


### PR DESCRIPTION
# WHAT
On applying the `cleanAll()` function to any form,  the `clean()` function is called per field in order to reset the field's value to its original value. As seen in the `Field.ts` file, the opposite is done as the `originalValue` instead of the current value is changed. This PR corrects this error by assigning the field's value back to it's original value on form clean up. Only at this point can we say that the form is truly no longer `dirty` :)