### PR TITLE
ADD RESET ALL FUNCTION TO FORMS

### DIFF
--- a/__tests__/Field.spec.ts
+++ b/__tests__/Field.spec.ts
@@ -221,7 +221,7 @@ describe('Field', () => {
   })
 
   describe('reset', () => {
-    it('rests a field to the original value', () => {
+    it('resets a field to its original value', () => {
       const field = new Field('paco', 'string')
       field.set('ferran')
       expect(field.value).toBe('ferran')

--- a/__tests__/Field.spec.ts
+++ b/__tests__/Field.spec.ts
@@ -219,4 +219,14 @@ describe('Field', () => {
       expect(field._mapOut()).toBe(null)
     })
   })
+
+  describe('reset', () => {
+    it('rests a field to the original value', () => {
+      const field = new Field('paco', 'string')
+      field.set('ferran')
+      expect(field.value).toBe('ferran')
+      field.reset()
+      expect(field.value).toBe('paco')
+    })
+  })
 })

--- a/__tests__/Form.spec.ts
+++ b/__tests__/Form.spec.ts
@@ -155,6 +155,17 @@ describe('Form', () => {
     })
   })
 
+  describe('resetAll', () => {
+    it('resets form to its original values', () => {
+      form.setValues({ name: 'resetMe', age: 20 })
+      expect(form.get('name').value).toBe('resetMe')
+      expect(form.get('age').value).toBe("20")
+      form.resetAll()
+      expect(form.get('name').value).toBe('paco')
+      expect(form.get('age').value).toBe("0")
+    })
+  })
+
   describe('setErrors', () => {
     it('populates the fields with errors', () => {
       form.setErrors({ name: ['too short'] })

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -112,6 +112,10 @@ export default class Field {
     this.originalValue = this.value
   }
 
+  reset(): void {
+    this.value = this.originalValue
+  }
+
   setErrors(errors: Array<string> | null): void {
     this.errors = errors
   }

--- a/src/Form.ts
+++ b/src/Form.ts
@@ -81,12 +81,23 @@ export default class Form {
   }
 
   /**
-   * Cleans all the forms by reseting their original
-   * values
+   * Cleans all the forms by changing their original
+   * values to correspond to their current values
    */
   cleanAll(): void {
     forEach(this.fields, (field: Field) =>
       field.clean()
+    )
+  }
+
+  /**
+   * Reset all the forms to their original
+   * values thereby discarding all changes made
+   */
+
+  resetAll(): void {
+    forEach(this.fields, (field: Field) =>
+      field.reset()
     )
   }
 


### PR DESCRIPTION
#WHAT
This PR add a `resetAll()` method on the form to enable restoration to defaults, thereby discarding all changes made.