### PR TITLE
Use `isEqual` for `isDirty` getter in Field

### DIFF
--- a/__tests__/Field.spec.ts
+++ b/__tests__/Field.spec.ts
@@ -229,4 +229,21 @@ describe('Field', () => {
       expect(field.value).toBe('paco')
     })
   })
+
+  describe('isDirty', () => {
+    it('works correctly when values change', () => {
+      const field = new Field('paco', 'string')
+      expect(field.isDirty).toBeFalsy()
+      field.set('paquito')
+      expect(field.isDirty).toBeTruthy()
+    })
+    describe('for arrays', () => {
+      it('works correctly when values change', () => {
+        const field = new Field([1, 2], 'string')
+        expect(field.isDirty).toBeFalsy()
+        field.set([2, 1])
+        expect(field.isDirty).toBeTruthy()
+      })
+    })
+  })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "factorial-form",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "description": "Factorial form library",
     "repository": {
         "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,6 +29,7 @@ export default [
       'lodash/some',
       'lodash/last',
       'lodash/isObject',
+      'lodash/isEqual',
       'moment',
       'flat',
       'mobx'

--- a/src/Field.ts
+++ b/src/Field.ts
@@ -1,5 +1,6 @@
 import { observable, action, computed, makeObservable } from 'mobx'
 import isFinite from 'lodash/isFinite'
+import isEqual from 'lodash/isEqual'
 import moment from 'moment'
 import { Type } from './types'
 import numberParser from './numberParser'
@@ -97,7 +98,7 @@ export default class Field {
   }
 
   get isDirty(): boolean {
-    return this.originalValue !== this.value
+    return !isEqual(this.originalValue, this.value)
   }
 
   mapAndSet(value: any): void {


### PR DESCRIPTION
This commit fixes an issue where the `isDirty` getter in Field was giving false negatives.

In javascript world:
```ts
console.log([1] === [1]) // `false`
```
This is because we don't check the values of the array, but its allocation in memory. Same happens with objects.

Even `factorial-form` doesn't officially support arrays or objects as fields, this change will luckily solve some small bugs we have in our frontend app (we already detected one).